### PR TITLE
Pin conan to <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 	zip_safe=False,
 	python_requires = '>=3.5',
 	install_requires = [
-		'conan>=1.7.4',
+		'conan>=1.7.4,<2',
 		'setuptools',
 		'ue4cli>=0.0.49',
 		'wheel'


### PR DESCRIPTION
Conan v2 is not compatible with the existing ue4cli, this should keep compatibility with existing code.

Workaround for #23 